### PR TITLE
Remove RabbitMQ from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ National Integration Adaptors - Adaptor for NHS 111 Post Event Message
 * Navigate to `ops/local`
 * Run script: `start-local-environment.sh`
 
-The above script builds necessary docker images and starts the SpringBoot service and RabbitMQ
+The above script builds necessary docker images and starts the SpringBoot service and ActiveMQ
 * REST service `localhost:100001`
 * ActiveMQ: `localhost:5672`
 


### PR DESCRIPTION
There was a remaining reference to RabbitMQ in the readme file, updating to replace with ActiveMQ.